### PR TITLE
Add foreign packets receiver feature and fix comp

### DIFF
--- a/WBLib.cmake
+++ b/WBLib.cmake
@@ -29,6 +29,7 @@ target_sources(wifibroadcast PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/src/WBReceiver.cpp
         ${CMAKE_CURRENT_LIST_DIR}/src/WBTransmitter.cpp
         ${CMAKE_CURRENT_LIST_DIR}/src/WBMultiPacketInjector.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/ForeignPacketsReceiver.cpp
         )
 target_include_directories(wifibroadcast PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/src/HelperSources

--- a/src/ForeignPacketsReceiver.cpp
+++ b/src/ForeignPacketsReceiver.cpp
@@ -44,6 +44,10 @@ void ForeignPacketsReceiver::on_foreign_packet(const uint8_t wlan_idx,const pcap
   }
   m_n_foreign_packets++;
   m_n_foreign_bytes+=static_cast<int64_t>(parsedPacket->payloadSize);
+  Stats new_stats{};
+  new_stats.curr_received_pps=static_cast<int>(m_foreign_packets_pps_calc.get_last_or_recalculate(m_n_foreign_packets,std::chrono::seconds(1)));
+  new_stats.curr_received_bps=static_cast<int>(m_foreign_packets_bps_calc.get_last_or_recalculate(m_n_foreign_bytes,std::chrono::seconds(1)));
+  m_curr_stats=new_stats;
 }
 
 void ForeignPacketsReceiver::m_loop() {
@@ -51,8 +55,5 @@ void ForeignPacketsReceiver::m_loop() {
 }
 
 ForeignPacketsReceiver::Stats ForeignPacketsReceiver::get_current_stats() {
-  Stats ret{};
-  ret.curr_received_pps=static_cast<int>(m_foreign_packets_pps_calc.get_last_or_recalculate(m_n_foreign_packets,std::chrono::seconds(1)));
-  ret.curr_received_bps=static_cast<int>(m_foreign_packets_bps_calc.get_last_or_recalculate(m_n_foreign_bytes,std::chrono::seconds(1)));
-  return ret;
+  return m_curr_stats;
 }

--- a/src/ForeignPacketsReceiver.cpp
+++ b/src/ForeignPacketsReceiver.cpp
@@ -1,0 +1,5 @@
+//
+// Created by consti10 on 17.12.22.
+//
+
+#include "ForeignPacketsReceiver.h"

--- a/src/ForeignPacketsReceiver.cpp
+++ b/src/ForeignPacketsReceiver.cpp
@@ -24,6 +24,12 @@ ForeignPacketsReceiver::ForeignPacketsReceiver(std::vector<std::string> wlans,st
   m_thread=std::make_unique<std::thread>(&ForeignPacketsReceiver::m_loop, this);
 }
 
+ForeignPacketsReceiver::~ForeignPacketsReceiver() {
+  m_receiver->stop();
+  if(m_thread->joinable())m_thread->join();
+  m_thread= nullptr;
+}
+
 void ForeignPacketsReceiver::on_foreign_packet(const uint8_t wlan_idx,const pcap_pkthdr &hdr,const uint8_t *pkt) {
   wifibroadcast::log::get_default()->debug("X got packet");
 }

--- a/src/ForeignPacketsReceiver.cpp
+++ b/src/ForeignPacketsReceiver.cpp
@@ -13,7 +13,13 @@ ForeignPacketsReceiver::ForeignPacketsReceiver(std::vector<std::string> wlans,st
   };
   auto cb2=[this](){
   };
-  m_receiver=std::make_unique<MultiRxPcapReceiver>(wlans,100,std::chrono::milliseconds(100),cb,cb2);
+  MultiRxPcapReceiver::Options options;
+  options.rxInterfaces=wlans;
+  options.dataCallback=cb;
+  options.logCallback=cb2;
+  options.log_interval=std::chrono::milliseconds(100);
+  options.radio_port=100;
+  m_receiver=std::make_unique<MultiRxPcapReceiver>(options);
   m_receiver->loop();
   m_thread=std::make_unique<std::thread>(&ForeignPacketsReceiver::m_loop, this);
 }

--- a/src/ForeignPacketsReceiver.cpp
+++ b/src/ForeignPacketsReceiver.cpp
@@ -19,7 +19,7 @@ ForeignPacketsReceiver::ForeignPacketsReceiver(std::vector<std::string> wlans,st
   options.logCallback=cb2;
   options.log_interval=std::chrono::milliseconds(100);
   options.radio_port=-1;
-  options.excluded_radio_ports=openhd_radio_ports;
+  options.excluded_radio_ports=m_openhd_radio_ports;
   m_receiver=std::make_unique<MultiRxPcapReceiver>(options);
   m_receiver->loop();
   m_thread=std::make_unique<std::thread>(&ForeignPacketsReceiver::m_loop, this);

--- a/src/ForeignPacketsReceiver.cpp
+++ b/src/ForeignPacketsReceiver.cpp
@@ -21,7 +21,6 @@ ForeignPacketsReceiver::ForeignPacketsReceiver(std::vector<std::string> wlans,st
   options.radio_port=-1;
   options.excluded_radio_ports=m_openhd_radio_ports;
   m_receiver=std::make_unique<MultiRxPcapReceiver>(options);
-  m_receiver->loop();
   m_thread=std::make_unique<std::thread>(&ForeignPacketsReceiver::m_loop, this);
 }
 

--- a/src/ForeignPacketsReceiver.cpp
+++ b/src/ForeignPacketsReceiver.cpp
@@ -18,7 +18,8 @@ ForeignPacketsReceiver::ForeignPacketsReceiver(std::vector<std::string> wlans,st
   options.dataCallback=cb;
   options.logCallback=cb2;
   options.log_interval=std::chrono::milliseconds(100);
-  options.radio_port=100;
+  options.radio_port=-1;
+  options.excluded_radio_ports=openhd_radio_ports;
   m_receiver=std::make_unique<MultiRxPcapReceiver>(options);
   m_receiver->loop();
   m_thread=std::make_unique<std::thread>(&ForeignPacketsReceiver::m_loop, this);

--- a/src/ForeignPacketsReceiver.cpp
+++ b/src/ForeignPacketsReceiver.cpp
@@ -6,7 +6,7 @@
 
 #include <utility>
 
-ForeignPacketsReceiver::ForeignPacketsReceiver(std::vector<std::string> wlans,std::vector<uint16_t> openhd_radio_ports):
+ForeignPacketsReceiver::ForeignPacketsReceiver(std::vector<std::string> wlans,std::vector<int> openhd_radio_ports):
   m_openhd_radio_ports(std::move(openhd_radio_ports)) {
   auto cb=[this](const uint8_t wlan_idx, const pcap_pkthdr &hdr, const uint8_t *pkt){
     on_foreign_packet(wlan_idx,hdr,pkt);

--- a/src/ForeignPacketsReceiver.cpp
+++ b/src/ForeignPacketsReceiver.cpp
@@ -53,6 +53,6 @@ void ForeignPacketsReceiver::m_loop() {
 ForeignPacketsReceiver::Stats ForeignPacketsReceiver::get_current_stats() {
   Stats ret{};
   ret.curr_received_pps=static_cast<int>(m_foreign_packets_pps_calc.get_last_or_recalculate(m_n_foreign_packets,std::chrono::seconds(1)));
-  ret.curr_received_pps=static_cast<int>(m_foreign_packets_bps_calc.get_last_or_recalculate(m_n_foreign_bytes,std::chrono::seconds(1)));
+  ret.curr_received_bps=static_cast<int>(m_foreign_packets_bps_calc.get_last_or_recalculate(m_n_foreign_bytes,std::chrono::seconds(1)));
   return ret;
 }

--- a/src/ForeignPacketsReceiver.cpp
+++ b/src/ForeignPacketsReceiver.cpp
@@ -36,7 +36,7 @@ ForeignPacketsReceiver::~ForeignPacketsReceiver() {
 }
 
 void ForeignPacketsReceiver::on_foreign_packet(const uint8_t wlan_idx,const pcap_pkthdr &hdr,const uint8_t *pkt) {
-  m_console->debug("X got packet");
+  //m_console->debug("X got packet");
   const auto parsedPacket = RawReceiverHelper::processReceivedPcapPacket(hdr, pkt,false);
   if(!parsedPacket.has_value()){
     m_console->warn("Discarding packet due to pcap parsing error!");

--- a/src/ForeignPacketsReceiver.cpp
+++ b/src/ForeignPacketsReceiver.cpp
@@ -3,3 +3,25 @@
 //
 
 #include "ForeignPacketsReceiver.h"
+
+#include <utility>
+
+ForeignPacketsReceiver::ForeignPacketsReceiver(std::vector<std::string> wlans,std::vector<uint16_t> openhd_radio_ports):
+  m_openhd_radio_ports(std::move(openhd_radio_ports)) {
+  auto cb=[this](const uint8_t wlan_idx, const pcap_pkthdr &hdr, const uint8_t *pkt){
+    on_foreign_packet(wlan_idx,hdr,pkt);
+  };
+  auto cb2=[this](){
+  };
+  m_receiver=std::make_unique<MultiRxPcapReceiver>(wlans,100,std::chrono::milliseconds(100),cb,cb2);
+  m_receiver->loop();
+  m_thread=std::make_unique<std::thread>(&ForeignPacketsReceiver::m_loop, this);
+}
+
+void ForeignPacketsReceiver::on_foreign_packet(const uint8_t wlan_idx,const pcap_pkthdr &hdr,const uint8_t *pkt) {
+  wifibroadcast::log::get_default()->debug("X got packet");
+}
+
+void ForeignPacketsReceiver::m_loop() {
+  m_receiver->loop();
+}

--- a/src/ForeignPacketsReceiver.h
+++ b/src/ForeignPacketsReceiver.h
@@ -13,12 +13,12 @@
 
 class ForeignPacketsReceiver {
  public:
-  explicit ForeignPacketsReceiver(std::vector<std::string> wlans,std::vector<uint16_t> openhd_radio_ports);
+  explicit ForeignPacketsReceiver(std::vector<std::string> wlans,std::vector<int> openhd_radio_ports);
  private:
   void on_foreign_packet(uint8_t wlan_idx, const pcap_pkthdr &hdr, const uint8_t *pkt);
   void m_loop();
   std::unique_ptr<MultiRxPcapReceiver> m_receiver;
-  std::vector<uint16_t> m_openhd_radio_ports;
+  std::vector<int> m_openhd_radio_ports;
   std::unique_ptr<std::thread> m_thread;
 };
 

--- a/src/ForeignPacketsReceiver.h
+++ b/src/ForeignPacketsReceiver.h
@@ -13,9 +13,13 @@
 
 class ForeignPacketsReceiver {
  public:
+  explicit ForeignPacketsReceiver(std::vector<std::string> wlans,std::vector<uint16_t> openhd_radio_ports);
  private:
-
+  void on_foreign_packet(uint8_t wlan_idx, const pcap_pkthdr &hdr, const uint8_t *pkt);
+  void m_loop();
+  std::unique_ptr<MultiRxPcapReceiver> m_receiver;
   std::vector<uint16_t> m_openhd_radio_ports;
+  std::unique_ptr<std::thread> m_thread;
 };
 
 #endif  // WIFIBROADCAST_SRC_FOREIGNPACKETSRECEIVER_H_

--- a/src/ForeignPacketsReceiver.h
+++ b/src/ForeignPacketsReceiver.h
@@ -20,8 +20,8 @@ class ForeignPacketsReceiver {
   explicit ForeignPacketsReceiver(std::vector<std::string> wlans,std::vector<int> openhd_radio_ports,std::shared_ptr<spdlog::logger> console= nullptr);
   ~ForeignPacketsReceiver();
   struct Stats{
-    int curr_received_pps;
-    int curr_received_bps;
+    int curr_received_pps=0;
+    int curr_received_bps=0;
     std::string to_string()const{
       return fmt::format("curr pps:{}, curr bps:{}",curr_received_pps,curr_received_bps);
     }
@@ -36,6 +36,8 @@ class ForeignPacketsReceiver {
   std::unique_ptr<std::thread> m_thread;
   int64_t m_n_foreign_packets=0;
   int64_t m_n_foreign_bytes=0;
+  //TODO make me atomic
+  Stats m_curr_stats;
   BitrateCalculator m_foreign_packets_bps_calc{};
   PacketsPerSecondCalculator m_foreign_packets_pps_calc{};
 };

--- a/src/ForeignPacketsReceiver.h
+++ b/src/ForeignPacketsReceiver.h
@@ -1,0 +1,21 @@
+//
+// Created by consti10 on 17.12.22.
+//
+
+#ifndef WIFIBROADCAST_SRC_FOREIGNPACKETSRECEIVER_H_
+#define WIFIBROADCAST_SRC_FOREIGNPACKETSRECEIVER_H_
+
+#include <cstdint>
+#include <vector>
+#include <memory>
+
+#include "RawReceiver.hpp"
+
+class ForeignPacketsReceiver {
+ public:
+ private:
+
+  std::vector<uint16_t> m_openhd_radio_ports;
+};
+
+#endif  // WIFIBROADCAST_SRC_FOREIGNPACKETSRECEIVER_H_

--- a/src/ForeignPacketsReceiver.h
+++ b/src/ForeignPacketsReceiver.h
@@ -16,14 +16,27 @@
 // most likely because of the radio port - we really need to migrate to a single rx instance for all cards
 class ForeignPacketsReceiver {
  public:
-  explicit ForeignPacketsReceiver(std::vector<std::string> wlans,std::vector<int> openhd_radio_ports);
+  explicit ForeignPacketsReceiver(std::vector<std::string> wlans,std::vector<int> openhd_radio_ports,std::shared_ptr<spdlog::logger> console= nullptr);
   ~ForeignPacketsReceiver();
+  struct Stats{
+    int curr_received_pps;
+    int curr_received_bps;
+    std::string to_string()const{
+      return fmt::format("curr pps:{}, curr bps:{}",curr_received_pps,curr_received_bps);
+    }
+  };
+  Stats get_current_stats();
  private:
   void on_foreign_packet(uint8_t wlan_idx, const pcap_pkthdr &hdr, const uint8_t *pkt);
   void m_loop();
+  std::shared_ptr<spdlog::logger> m_console;
   std::unique_ptr<MultiRxPcapReceiver> m_receiver;
   std::vector<int> m_openhd_radio_ports;
   std::unique_ptr<std::thread> m_thread;
+  int64_t m_n_foreign_packets=0;
+  int64_t m_n_foreign_bytes=0;
+  BitrateCalculator m_foreign_packets_bps_calc{};
+  PacketsPerSecondCalculator m_foreign_packets_pps_calc{};
 };
 
 #endif  // WIFIBROADCAST_SRC_FOREIGNPACKETSRECEIVER_H_

--- a/src/ForeignPacketsReceiver.h
+++ b/src/ForeignPacketsReceiver.h
@@ -11,9 +11,13 @@
 
 #include "RawReceiver.hpp"
 
+// Helper - get (most likely all) packets that are not coming from a running openhd instance,
+// but rather someone else talking on this channel.
+// most likely because of the radio port - we really need to migrate to a single rx instance for all cards
 class ForeignPacketsReceiver {
  public:
   explicit ForeignPacketsReceiver(std::vector<std::string> wlans,std::vector<int> openhd_radio_ports);
+  ~ForeignPacketsReceiver();
  private:
   void on_foreign_packet(uint8_t wlan_idx, const pcap_pkthdr &hdr, const uint8_t *pkt);
   void m_loop();

--- a/src/ForeignPacketsReceiver.h
+++ b/src/ForeignPacketsReceiver.h
@@ -14,6 +14,7 @@
 // Helper - get (most likely all) packets that are not coming from a running openhd instance,
 // but rather someone else talking on this channel.
 // most likely because of the radio port - we really need to migrate to a single rx instance for all cards
+// but for now, it is enough for us.
 class ForeignPacketsReceiver {
  public:
   explicit ForeignPacketsReceiver(std::vector<std::string> wlans,std::vector<int> openhd_radio_ports,std::shared_ptr<spdlog::logger> console= nullptr);

--- a/src/HelperSources/SocketHelper.hpp
+++ b/src/HelperSources/SocketHelper.hpp
@@ -271,6 +271,7 @@ class UDPReceiver {
     //saddr.sin_addr.s_addr = inet_addr(client_addr.c_str());
     inet_aton(destIp.c_str(), (in_addr *) &saddr.sin_addr.s_addr);
     saddr.sin_port = htons((uint16_t)  destPort);
+    // send from the currently bound UDP port to the destination address
     const auto ret=sendto(mSocket, packet, packetSize, 0, (const struct sockaddr *) &saddr,
                             sizeof(saddr));
     if(ret <0 || ret != packetSize){

--- a/src/HelperSources/StringHelper.hpp
+++ b/src/HelperSources/StringHelper.hpp
@@ -23,6 +23,16 @@ class StringHelper {
     return ss.str();
   }
 
+  static std::string string_vec_as_string(const std::vector<std::string>& v){
+    std::stringstream ss;
+    ss << "[";
+    for (const auto i: v) {
+      ss << i << ",";
+    }
+    ss << "]";
+    return ss.str();
+  }
+
   template<typename T, std::size_t S>
   static std::string arrayAsString(const std::array<T, S> &a) {
     std::stringstream ss;

--- a/src/HelperSources/StringHelper.hpp
+++ b/src/HelperSources/StringHelper.hpp
@@ -16,8 +16,11 @@ class StringHelper {
   static std::string vectorAsString(const std::vector<T> &v) {
     std::stringstream ss;
     ss << "[";
-    for (const auto i: v) {
-      ss << (int) i << ",";
+    for(int i=0;i<v.size();i++){
+      ss << std::to_string(i);
+      if(i!=v.size()-1){
+        ss<<",";
+      }
     }
     ss << "]";
     return ss.str();
@@ -26,8 +29,11 @@ class StringHelper {
   static std::string string_vec_as_string(const std::vector<std::string>& v){
     std::stringstream ss;
     ss << "[";
-    for (const auto i: v) {
-      ss << i << ",";
+    for(int i=0;i<v.size();i++){
+      ss << i;
+      if(i!=v.size()-1){
+        ss<<",";
+      }
     }
     ss << "]";
     return ss.str();
@@ -37,8 +43,11 @@ class StringHelper {
   static std::string arrayAsString(const std::array<T, S> &a) {
     std::stringstream ss;
     ss << "[";
-    for (const auto i: a) {
-      ss << (int) i << ",";
+    for(int i=0;i<a.size();i++){
+      ss << std::to_string(i);
+      if(i!=a.size()-1){
+        ss<<",";
+      }
     }
     ss << "]";
     return ss.str();

--- a/src/RawReceiver.hpp
+++ b/src/RawReceiver.hpp
@@ -398,7 +398,7 @@ class MultiRxPcapReceiver {
             // limit logging here
             const auto elapsed=std::chrono::steady_clock::now()-m_last_receiver_error_log;
             if(elapsed>std::chrono::seconds(1)){
-              wifibroadcast::log::get_default()->warn(StringFormat::convert("RawReceiver errors %d on pcap fds %d (wlan %s)",get_n_receiver_errors(),i,rxInterfaces[i].c_str()));
+              wifibroadcast::log::get_default()->warn("RawReceiver errors {} on pcap fds {} (wlan {})",get_n_receiver_errors(),i,rxInterfaces[i]);
               m_last_receiver_error_log=std::chrono::steady_clock::now();
             }
           }else{

--- a/src/RawReceiver.hpp
+++ b/src/RawReceiver.hpp
@@ -407,7 +407,7 @@ class MultiRxPcapReceiver {
     std::stringstream ss;
     ss << "MultiRxPcapReceiver ";
     if(m_options.radio_port==-1){
-      ss<<"Excluded radio_ports:"<<m_options.excluded_radio_ports.size();
+      ss<<"Excluded radio_ports:"<<StringHelper::vectorAsString(m_options.excluded_radio_ports);
     }else{
       ss<<"Assigned radio_port:"<<m_options.radio_port;
     }

--- a/src/RawReceiver.hpp
+++ b/src/RawReceiver.hpp
@@ -15,6 +15,7 @@
 #include <functional>
 #include <unordered_map>
 #include <variant>
+#include <optional>
 
 #include "HelperSources/Helper.hpp"
 #include "HelperSources/TimeHelper.hpp"

--- a/src/RawReceiver.hpp
+++ b/src/RawReceiver.hpp
@@ -21,6 +21,7 @@
 #include "Ieee80211Header.hpp"
 #include "RadiotapHeader.hpp"
 #include "wifibroadcast-spdlog.h"
+#include "pcap_helper.h"
 
 // This is a single header-only file you can use to build your own wifibroadcast
 // link
@@ -29,23 +30,12 @@
 // stuff that helps for receiving data with pcap
 namespace RawReceiverHelper {
 
-static std::string pcap_tstamp_types_to_string(int* ts_types,int n){
-  std::stringstream ss;
-  ss<<"[";
-  for(int i=0;i<n;i++){
-    const char *name = pcap_tstamp_type_val_to_name(ts_types[i]);
-    const char *description = pcap_tstamp_type_val_to_description(ts_types[i]);
-    ss<<name<<"="<<description<<",";
-  }
-  ss<<"]";
-  return ss.str();
-}
 
 // Set timestamp type to PCAP_TSTAMP_HOST if available
 static void iteratePcapTimestamps(pcap_t *ppcap) {
   int *availableTimestamps;
   const int nTypes = pcap_list_tstamp_types(ppcap, &availableTimestamps);
-  wifibroadcast::log::get_default()->debug("TS types:{}", pcap_tstamp_types_to_string(availableTimestamps,nTypes));
+  wifibroadcast::log::get_default()->debug("TS types:{}", wifibroadcast::pcap_helper::tstamp_types_to_string(availableTimestamps,nTypes));
   //"N available timestamp types "<<nTypes<<"\n";
   for (int i = 0; i < nTypes; i++) {
     if (availableTimestamps[i] == PCAP_TSTAMP_HOST) {
@@ -93,7 +83,6 @@ static std::string create_program_specific_port_only(const std::string &wlan,con
   }
   return program;
 }
-
 
 static void set_pcap_filer(const std::string &wlan,pcap_t* ppcap,const int radio_port){
   const int link_encap = pcap_datalink(ppcap);

--- a/src/RawReceiver.hpp
+++ b/src/RawReceiver.hpp
@@ -119,10 +119,10 @@ static void set_pcap_filer2(const std::string &wlan,pcap_t* ppcap,const std::vec
 // copy paste from svpcom
 // I think this one opens the rx interface with pcap and then sets a filter such that only packets pass through for the selected radio port
 static pcap_t *openRxWithPcap(const std::string &wlan, const int radio_port) {
-  pcap_t *ppcap;
+  pcap_t *ppcap= nullptr;
   char errbuf[PCAP_ERRBUF_SIZE];
   ppcap = pcap_create(wlan.c_str(), errbuf);
-  if (ppcap == NULL) {
+  if (ppcap == nullptr) {
     wifibroadcast::log::get_default()->error("Unable to open interface {} in pcap: {}", wlan.c_str(), errbuf);
   }
   iteratePcapTimestamps(ppcap);

--- a/src/RawReceiver.hpp
+++ b/src/RawReceiver.hpp
@@ -75,11 +75,11 @@ static pcap_t *openRxWithPcap(const std::string &wlan, const int radio_port) {
   switch (link_encap) {
     case DLT_PRISM_HEADER:
       wifibroadcast::log::get_default()->debug("{} has DLT_PRISM_HEADER Encap",wlan);
-      program = StringFormat::convert("!(radio[0x4a:4]==0x13223344 && radio[0x4e:2] == 0x55%.2x)", radio_port);
+      program = StringFormat::convert("radio[0x4a:4]==0x13223344 && radio[0x4e:2] == 0x55%.2x", radio_port);
       break;
     case DLT_IEEE802_11_RADIO:
       wifibroadcast::log::get_default()->debug("{} has DLT_IEEE802_11_RADIO Encap",wlan);
-      program = StringFormat::convert("!(ether[0x0a:4]==0x13223344 && ether[0x0e:2] == 0x55%.2x)", radio_port);
+      program = StringFormat::convert("ether[0x0a:4]==0x13223344 && ether[0x0e:2] == 0x55%.2x", radio_port);
       break;
     default:{
       wifibroadcast::log::get_default()->error("unknown encapsulation on {}", wlan.c_str());

--- a/src/RawReceiver.hpp
+++ b/src/RawReceiver.hpp
@@ -145,6 +145,7 @@ static pcap_t *openRxWithPcap(const std::string &wlan, const int radio_port) {
     wifibroadcast::log::get_default()->error("set_nonblock failed: {}",
                                        errbuf);
   }
+  // only let messages with the right radio port through
   set_pcap_filer(wlan,ppcap,radio_port);
   return ppcap;
 }

--- a/src/RawReceiver.hpp
+++ b/src/RawReceiver.hpp
@@ -75,11 +75,11 @@ static pcap_t *openRxWithPcap(const std::string &wlan, const int radio_port) {
   switch (link_encap) {
     case DLT_PRISM_HEADER:
       wifibroadcast::log::get_default()->debug("{} has DLT_PRISM_HEADER Encap",wlan);
-      program = StringFormat::convert("radio[0x4a:4]==0x13223344 && radio[0x4e:2] == 0x55%.2x", radio_port);
+      program = StringFormat::convert("!(radio[0x4a:4]==0x13223344 && radio[0x4e:2] == 0x55%.2x)", radio_port);
       break;
     case DLT_IEEE802_11_RADIO:
       wifibroadcast::log::get_default()->debug("{} has DLT_IEEE802_11_RADIO Encap",wlan);
-      program = StringFormat::convert("ether[0x0a:4]==0x13223344 && ether[0x0e:2] == 0x55%.2x", radio_port);
+      program = StringFormat::convert("!(ether[0x0a:4]==0x13223344 && ether[0x0e:2] == 0x55%.2x)", radio_port);
       break;
     default:{
       wifibroadcast::log::get_default()->error("unknown encapsulation on {}", wlan.c_str());

--- a/src/RawReceiver.hpp
+++ b/src/RawReceiver.hpp
@@ -405,7 +405,13 @@ class MultiRxPcapReceiver {
     mReceiverFDs.resize(N_RECEIVERS);
     memset(mReceiverFDs.data(), '\0', mReceiverFDs.size() * sizeof(pollfd));
     std::stringstream ss;
-    ss << "MultiRxPcapReceiver" << " Assigned ID: " << m_options.radio_port << " Assigned WLAN(s):[";
+    ss << "MultiRxPcapReceiver ";
+    if(m_options.radio_port==-1){
+      ss<<"Excluded radio_ports:"<<m_options.excluded_radio_ports.size();
+    }else{
+      ss<<"Assigned radio_port:"<<m_options.radio_port;
+    }
+    ss << " Assigned WLAN(s):[";
     for (const auto &s: m_options.rxInterfaces) {
       ss << s << ",";
     }

--- a/src/RawReceiver.hpp
+++ b/src/RawReceiver.hpp
@@ -411,11 +411,7 @@ class MultiRxPcapReceiver {
     }else{
       ss<<"Assigned radio_port:"<<m_options.radio_port;
     }
-    ss << " Assigned WLAN(s):[";
-    for (const auto &s: m_options.rxInterfaces) {
-      ss << s << ",";
-    }
-    ss << "]";
+    ss<<" Assigned WLAN(s):"<<StringHelper::string_vec_as_string(m_options.rxInterfaces);
     ss << " LOG_INTERVAL(ms)" << (int) m_options.log_interval.count();
     wifibroadcast::log::get_default()->debug(ss.str());
 

--- a/src/RawTransmitter.hpp
+++ b/src/RawTransmitter.hpp
@@ -19,7 +19,7 @@
 #include <chrono>
 #include <optional>
 #include <poll.h>
-#include <pcap.h>
+#include "pcap_helper.h"
 
 // This is a single header-only file you can use to build your own wifibroadcast link
 // It doesn't specify if / what FEC to use and so on
@@ -98,11 +98,12 @@ static pcap_t *openTxWithPcap(const std::string &wlan) {
   // NOTE: Immediate not needed on TX
   if (pcap_activate(p) != 0){
     wifibroadcast::log::get_default()->error("pcap_activate failed: {}",
-                                       pcap_geterr(p));
+                                             pcap_geterr(p));
   }
   //if (pcap_setnonblock(p, 1, errbuf) != 0) wifibroadcast::log::get_default()->warn(string_format("set_nonblock failed: %s", errbuf));
   return p;
 }
+
 }
 
 class IRawPacketInjector {

--- a/src/WBReceiver.cpp
+++ b/src/WBReceiver.cpp
@@ -51,9 +51,13 @@ WBReceiver::WBReceiver(ROptions options1, OUTPUT_DATA_CALLBACK output_data_callb
   }else{
     m_console=console;
   }
-  receiver = std::make_unique<MultiRxPcapReceiver>(options.rxInterfaces, options.radio_port,std::chrono::seconds(1),
-                                                   notstd::bind_front(&WBReceiver::processPacket, this),
-                                                   notstd::bind_front(&WBReceiver::recalculate_statistics, this));
+  MultiRxPcapReceiver::Options multi_rx_options;
+  multi_rx_options.rxInterfaces=options.rxInterfaces;
+  multi_rx_options.dataCallback=notstd::bind_front(&WBReceiver::processPacket, this);
+  multi_rx_options.logCallback=notstd::bind_front(&WBReceiver::recalculate_statistics, this);
+  multi_rx_options.log_interval=std::chrono::seconds (1);
+  multi_rx_options.radio_port=options.radio_port;
+  receiver = std::make_unique<MultiRxPcapReceiver>(multi_rx_options);
   m_console->info("WFB-RX RADIO_PORT: {}",(int) options.radio_port);
 }
 

--- a/src/WBReceiverStats.hpp
+++ b/src/WBReceiverStats.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 
 #include "HelperSources/TimeHelper.hpp"
+#include <optional>
 
 // TODO what happens here has to be decided yet
 // write the fec decoding stats (and optionally RSSI ) for each rx stream

--- a/src/pcap_helper.h
+++ b/src/pcap_helper.h
@@ -1,0 +1,30 @@
+//
+// Created by consti10 on 17.12.22.
+//
+
+#ifndef WIFIBROADCAST_SRC_PCAP_HELPER_H_
+#define WIFIBROADCAST_SRC_PCAP_HELPER_H_
+
+#include <string>
+
+#include <pcap/pcap.h>
+
+namespace wifibroadcast::pcap_helper{
+
+// debugging
+static std::string tstamp_types_to_string(int* ts_types,int n){
+  std::stringstream ss;
+  ss<<"[";
+  for(int i=0;i<n;i++){
+    const char *name = pcap_tstamp_type_val_to_name(ts_types[i]);
+    const char *description = pcap_tstamp_type_val_to_description(ts_types[i]);
+    ss<<name<<"="<<description<<",";
+  }
+  ss<<"]";
+  return ss.str();
+}
+
+
+}
+
+#endif  // WIFIBROADCAST_SRC_PCAP_HELPER_H_


### PR DESCRIPTION
foreign packets receiver: quick and dirty (but working) impl of a receiver that helps to add a listener for non-openhd (aka foreign) wifi packets. Intention is to measure the traffic of other networks and use it as a param vor bitrate controll, but there are some inherent issues with that and therefore i am not using it r.n in openhd.

Other functionalities are left untouched.