### PR TITLE
eature - add 2 modes of operation, packet queue or block 

### DIFF
--- a/src/FECEnabled.hpp
+++ b/src/FECEnabled.hpp
@@ -136,6 +136,16 @@ class FECEncoder {
   MinMaxAvg<uint16_t> m_curr_fec_block_sizes{};
  public:
   /**
+   * Helper for encoding a FEC "block", note that @param fragments size needs to be <=m_curr_fec_k_max
+   */
+  void tmp_encode_block(std::vector<std::shared_ptr<std::vector<uint8_t>>> fragments){
+    for(int i=0;i<fragments.size();i++){
+      const bool end_block=i==fragments.size()-1;
+      const auto res=encodePacket(fragments[i]->data(),fragments[i]->size(),end_block);
+      assert(end_block==res);
+    }
+  }
+  /**
    * encode packet such that it can be decoded by FECDecoder. Data is forwarded via the callback.
    * @param endBlock if true, the FEC step is applied immediately
    * else, the FEC step is only applied if reaching m_curr_fec_k_max

--- a/src/FECEnabled.hpp
+++ b/src/FECEnabled.hpp
@@ -91,7 +91,7 @@ static constexpr const uint16_t
     MAX_TOTAL_FRAGMENTS_PER_BLOCK = MAX_N_P_FRAGMENTS_PER_BLOCK + MAX_N_S_FRAGMENTS_PER_BLOCK;
 
 // For dynamic block sizes, we switched to a FEC overhead "percentage" value.
-// e.g. the final data throughput ~= original data troughput * fec overhead percentage
+// e.g. the final data throughput ~= original data throughput * fec overhead percentage
 static uint32_t calculate_n_secondary_fragments(uint32_t n_primary_fragments,uint32_t fec_overhead_perc){
   if(fec_overhead_perc<=0)return 0;
   return std::lroundf(static_cast<float>(n_primary_fragments) * static_cast<float>(fec_overhead_perc) / 100.0f);

--- a/src/RawTransmitter.hpp
+++ b/src/RawTransmitter.hpp
@@ -118,7 +118,7 @@ class IRawPacketInjector {
 };
 
 // Pcap Transmitter injects packets into the wifi adapter using pcap
-// It does not specify what the payload is and therefore is just a really small wrapper around the pcap interface
+// It does not specify what the payload is and therefore is just a tiny wrapper around the pcap interface
 // that properly opens / closes the interface on construction/destruction
 class PcapTransmitter : public IRawPacketInjector {
  public:

--- a/src/WBMultiPacketInjector.h
+++ b/src/WBMultiPacketInjector.h
@@ -8,6 +8,7 @@
 #include "RawTransmitter.hpp"
 #include "readerwriterqueue/readerwritercircularbuffer.h"
 
+// TODO unimplemented right now, migrate
 // Can be used by multiple WB TX / RX instance(s)
 // This has the benefit that all packets go through a single class instance,
 // which makes counting total n of packets or reasoning about packets in the tx queue much easier.

--- a/src/WBTransmitter.cpp
+++ b/src/WBTransmitter.cpp
@@ -54,9 +54,9 @@ WBTransmitter::WBTransmitter(RadiotapHeader::UserSelectableParams radioTapHeader
         notstd::bind_front(&WBTransmitter::encrypt_and_send_packet, this);
   }
   if(options.use_block_queue){
-    m_block_queue=std::make_unique<moodycamel::BlockingReaderWriterCircularBuffer<std::shared_ptr<EnqueuedBlock>>>(2);
+    m_block_queue=std::make_unique<moodycamel::BlockingReaderWriterCircularBuffer<std::shared_ptr<EnqueuedBlock>>>(options.block_data_queue_size);
   }else{
-    m_packet_queue=std::make_unique<moodycamel::BlockingReaderWriterCircularBuffer<std::shared_ptr<EnqueuedPacket>>>(128);
+    m_packet_queue=std::make_unique<moodycamel::BlockingReaderWriterCircularBuffer<std::shared_ptr<EnqueuedPacket>>>(options.packet_data_queue_size);
   }
   // the rx needs to know if FEC is enabled or disabled. Note, both variable and fixed fec counts as FEC enabled
   m_sess_key_packet.IS_FEC_ENABLED = kEnableFec;

--- a/src/WBTransmitter.cpp
+++ b/src/WBTransmitter.cpp
@@ -30,7 +30,7 @@ WBTransmitter::WBTransmitter(RadiotapHeader::UserSelectableParams radioTapHeader
       m_radioTapHeaderParams(radioTapHeaderParams),
     kEnableFec(options.enable_fec),
     m_tx_fec_options(options.tx_fec_options),
-    mRadiotapHeader{RadiotapHeader{m_radioTapHeaderParams}},
+      m_radiotap_header{RadiotapHeader{m_radioTapHeaderParams}},
     m_console(std::move(opt_console)){
   if(!m_console){
     m_console=wifibroadcast::log::create_or_get("wb_tx"+std::to_string(options.radio_port));
@@ -38,30 +38,31 @@ WBTransmitter::WBTransmitter(RadiotapHeader::UserSelectableParams radioTapHeader
   assert(m_console);
   m_console->info("WBTransmitter radio_port: {} wlan: {} keypair:{}", options.radio_port, options.wlan.c_str(),
                   (options.keypair.has_value() ? options.keypair.value() : "none" ));
-  m_encryptor.makeNewSessionKey(sessionKeyPacket.sessionKeyNonce, sessionKeyPacket.sessionKeyData);
+  m_encryptor.makeNewSessionKey(m_sess_key_packet.sessionKeyNonce,
+                                m_sess_key_packet.sessionKeyData);
   if (kEnableFec) {
     // for variable k we manually specify when to end the block, of course we cannot do more than what the FEC impl. supports
     // and / or what the max compute allows (NOTE: compute increases exponentially with increasing length).
     const int kMax= options.tx_fec_options.fixed_k > 0 ? options.tx_fec_options.fixed_k : MAX_N_P_FRAGMENTS_PER_BLOCK;
     m_console->info("fec enabled, kMax:{}",kMax);
     m_fec_encoder = std::make_unique<FECEncoder>(kMax, options.tx_fec_options.overhead_percentage);
-    m_fec_encoder->outputDataCallback = notstd::bind_front(&WBTransmitter::sendFecPrimaryOrSecondaryFragment, this);
+    m_fec_encoder->outputDataCallback = notstd::bind_front(&WBTransmitter::encrypt_and_send_packet, this);
   } else {
     m_console->info("fec disabled");
     m_fec_disabled_encoder = std::make_unique<FECDisabledEncoder>();
     m_fec_disabled_encoder->outputDataCallback =
-        notstd::bind_front(&WBTransmitter::sendFecPrimaryOrSecondaryFragment, this);
+        notstd::bind_front(&WBTransmitter::encrypt_and_send_packet, this);
   }
   // the rx needs to know if FEC is enabled or disabled. Note, both variable and fixed fec counts as FEC enabled
-  sessionKeyPacket.IS_FEC_ENABLED = kEnableFec;
+  m_sess_key_packet.IS_FEC_ENABLED = kEnableFec;
   // send session key a couple of times on startup to make it more likely an already running rx picks it up immediately
   m_console->info("Sending Session key on startup");
   for (int i = 0; i < 5; i++) {
-    sendSessionKey();
+    send_session_key();
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
   // next session key in delta ms if packets are being fed
-  session_key_announce_ts = std::chrono::steady_clock::now()+SESSION_KEY_ANNOUNCE_DELTA;
+  m_session_key_announce_ts = std::chrono::steady_clock::now()+SESSION_KEY_ANNOUNCE_DELTA;
 
   m_process_data_thread_run=true;
   m_process_data_thread=std::make_unique<std::thread>(&WBTransmitter::loop_process_data, this);
@@ -74,107 +75,83 @@ WBTransmitter::~WBTransmitter() {
   }
 }
 
-void WBTransmitter::sendPacket(const AbstractWBPacket &abstractWbPacket) {
-  count_bytes_data_injected+=abstractWbPacket.payloadSize;
-  mIeee80211Header.writeParams(options.radio_port, ieee80211_seq);
-  ieee80211_seq += 16;
-  //mIeee80211Header.printSequenceControl();
-  std::lock_guard<std::mutex> guard(m_radiotapHeaderMutex);
-  const auto injectionTime = m_pcap_transmitter.injectPacket(mRadiotapHeader, mIeee80211Header, abstractWbPacket);
-  if(injectionTime>MAX_SANE_INJECTION_TIME){
-    count_tx_injections_error_hint++;
-    //m_console->warn("Injecting PCAP packet took really long:",MyTimeHelper::R(injectionTime));
+bool WBTransmitter::try_enqueue_packet(std::shared_ptr<std::vector<uint8_t>> packet) {
+  assert(!options.use_block_queue);
+  if (packet->empty() || packet->size() > FEC_MAX_PAYLOAD_SIZE) {
+    m_console->warn("Fed packet with incompatible size:{}",packet->size());
+    return false;
   }
-  nInjectedPackets++;
+  m_count_bytes_data_provided +=packet->size();
+  auto item=std::make_shared<EnqueuedPacket>();
+  item->data=packet;
+  const bool res= m_packet_queue.try_enqueue(item);
+  if(!res){
+    m_n_dropped_packets++;
+    // TODO not exactly the correct solution - include dropped packets in the seq nr, such that they are included
+    // in the loss (perc) on the ground
+    m_curr_seq_nr++;
+  }
+  return res;
 }
 
-void WBTransmitter::sendFecPrimaryOrSecondaryFragment(const uint64_t nonce,
-                                                      const uint8_t *payload,
-                                                      const std::size_t payloadSize) {
+bool WBTransmitter::try_enqueue_block(std::vector<std::shared_ptr<std::vector<uint8_t>>> fragments,int max_block_size) {
+  assert(options.use_block_queue);
+  assert(kEnableFec);
+  for(const auto& fragment:fragments){
+    if (fragment->empty() || fragment->size() > FEC_MAX_PAYLOAD_SIZE) {
+      m_console->warn("Fed fragment with incompatible size:{}",fragment->size());
+      return false;
+    }
+    m_count_bytes_data_provided +=fragment->size();
+  }
+  auto item=std::make_shared<EnqueuedBlock>();
+  item->fragments=fragments;
+  item->max_block_size=max_block_size;
+  const bool res= m_block_queue.try_enqueue(item);
+  if(!res){
+    m_n_dropped_packets+=fragments.size();
+    m_curr_seq_nr+=fragments.size();
+  }
+  return res;
+}
+
+void WBTransmitter::send_packet(const AbstractWBPacket &abstractWbPacket) {
+  m_count_bytes_data_injected +=abstractWbPacket.payloadSize;
+  mIeee80211Header.writeParams(options.radio_port, m_ieee80211_seq);
+  m_ieee80211_seq += 16;
+  //mIeee80211Header.printSequenceControl();
+  std::lock_guard<std::mutex> guard(m_radiotapHeaderMutex);
+  const auto injectionTime = m_pcap_transmitter.injectPacket(
+      m_radiotap_header, mIeee80211Header, abstractWbPacket);
+  if(injectionTime>MAX_SANE_INJECTION_TIME){
+    m_count_tx_injections_error_hint++;
+    //m_console->warn("Injecting PCAP packet took really long:",MyTimeHelper::R(injectionTime));
+  }
+  m_n_injected_packets++;
+}
+
+void WBTransmitter::encrypt_and_send_packet(const uint64_t nonce,const uint8_t *payload,const std::size_t payloadSize) {
   //m_console->info("WBTransmitter::sendFecBlock {}",(int)payloadSize);
   const WBDataHeader wbDataHeader(nonce,m_curr_seq_nr);
   m_curr_seq_nr++;
-  const auto encryptedData =
-      m_encryptor.encryptPacket(nonce, payload, payloadSize, wbDataHeader);
+  const auto encryptedData =m_encryptor.encryptPacket(nonce, payload, payloadSize, wbDataHeader);
   //
-  sendPacket({(const uint8_t *) &wbDataHeader, sizeof(WBDataHeader), encryptedData.data(), encryptedData.size()});
+  send_packet({(const uint8_t *)&wbDataHeader, sizeof(WBDataHeader),encryptedData.data(), encryptedData.size()});
 #ifdef ENABLE_ADVANCED_DEBUGGING
   //LatencyTestingPacket latencyTestingPacket;
   //sendPacket((uint8_t*)&latencyTestingPacket,sizeof(latencyTestingPacket));
 #endif
 }
 
-void WBTransmitter::sendSessionKey() {
-  sendPacket({(uint8_t *) &sessionKeyPacket, WBSessionKeyPacket::SIZE_BYTES});
-  nInjectedSessionKeypackets++;
+void WBTransmitter::send_session_key() {
+  send_packet({(uint8_t *)&m_sess_key_packet, WBSessionKeyPacket::SIZE_BYTES});
+  m_n_injected_sess_packets++;
 }
 
-std::string WBTransmitter::createDebugState() const {
-  std::stringstream ss;
-  // input packets & injected packets
-  const auto nInjectedDataPackets=nInjectedPackets-nInjectedSessionKeypackets;
-  //ss << runTimeSeconds << "\tTX:in:("<<nInputPackets<<")out:(" << nInjectedDataPackets << ":" << nInjectedSessionKeypackets << ")\n";
-  ss <<"TX:in:("<<nInputPackets<<")out:(" << nInjectedDataPackets << ":" << nInjectedSessionKeypackets << ")\n";
-  return ss.str();
-}
-
-bool WBTransmitter::enqueue_packet(const uint8_t *buf, size_t size,std::optional<bool> end_block) {
-  count_bytes_data_provided+=size;
-  auto packet=std::make_shared<std::vector<uint8_t>>(buf,buf+size);
-  auto item=std::make_shared<Item>();
-  item->data=packet;
-  item->end_block=end_block;
-  const bool res=m_data_queue.try_enqueue(item);
-  if(!res){
-    m_n_dropped_packets++;
-    // TODO not exactly the correct solution - include dropped packets in the seq nr, such that they are included
-    // in the loss (perc) on the ground
-    m_curr_seq_nr++;
-  }
-  return res;
-}
-
-bool WBTransmitter::enqueue_packet(std::shared_ptr<std::vector<uint8_t>> packet,std::optional<bool> end_block) {
-  count_bytes_data_provided+=packet->size();
-  auto item=std::make_shared<Item>();
-  item->data=packet;
-  item->end_block=end_block;
-  const bool res=m_data_queue.try_enqueue(item);
-  if(!res){
-    m_n_dropped_packets++;
-    // TODO not exactly the correct solution - include dropped packets in the seq nr, such that they are included
-    // in the loss (perc) on the ground
-    m_curr_seq_nr++;
-  }
-  return res;
-}
-
-void WBTransmitter::tmp_feed_frame_fragments(
-    const std::vector<std::shared_ptr<std::vector<uint8_t>>> &frame_fragments,bool use_fixed_fec_instead) {
-  // we calculated the best fit and fragmented the frame before calling this method
-  for(int i=0;i<frame_fragments.size();i++){
-    std::optional<bool> end_block=std::nullopt;
-    if(i==frame_fragments.size()-1){
-      end_block=true;
-    }else{
-      end_block=false;
-    }
-    if(use_fixed_fec_instead){
-      end_block=std::nullopt;
-    }
-    enqueue_packet(frame_fragments[i], end_block);
-    // TODO
-    // If we fail on any fragment while enqueueing a frame, there is no point in enqueueing the rest of the frame,
-    // since the rx cannot do anything with a partial frame missing a fragment anyways
-  }
-}
-
-void WBTransmitter::tmp_split_and_feed_frame_fragments(const std::vector<std::shared_ptr<std::vector<uint8_t>>> &frame_fragments,const int max_block_size) {
-  auto blocks=blocksize::split_frame_if_needed(frame_fragments,max_block_size);
-  for(auto& block:blocks){
-    //m_console->debug("max {} Has {} blocks",max_block_size,block.size());
-    tmp_feed_frame_fragments(block, false);
-  }
+std::string WBTransmitter::createDebugState()const{
+  const auto nInjectedDataPackets=
+      m_n_injected_packets - m_n_injected_sess_packets;
+  return fmt::format("Tx in:{} out:{}:{}", m_n_input_packets,nInjectedDataPackets, m_n_injected_sess_packets);
 }
 
 
@@ -183,50 +160,27 @@ void WBTransmitter::update_mcs_index(uint8_t mcs_index) {
   m_radioTapHeaderParams.mcs_index=mcs_index;
   auto newRadioTapHeader=RadiotapHeader{m_radioTapHeaderParams};
   std::lock_guard<std::mutex> guard(m_radiotapHeaderMutex);
-  mRadiotapHeader=newRadioTapHeader;
+  m_radiotap_header =newRadioTapHeader;
 }
 
 void WBTransmitter::loop_process_data() {
   SchedulingHelper::setThreadParamsMaxRealtime();
   static constexpr std::int64_t timeout_usecs=100*1000;
-  std::shared_ptr<Item> packet;
-  while (m_process_data_thread_run){
-    if(m_data_queue.wait_dequeue_timed(packet,timeout_usecs)){
-      feedPacket2(packet->data->data(),packet->data->size(),packet->end_block);
+  if(options.use_block_queue){
+    std::shared_ptr<EnqueuedBlock> frame;
+    while (m_process_data_thread_run){
+      if(m_block_queue.wait_dequeue_timed(frame,timeout_usecs)){
+        process_fec_block(frame->fragments, frame->max_block_size);
+      }
+    }
+  }else{
+    std::shared_ptr<EnqueuedPacket> packet;
+    while (m_process_data_thread_run){
+      if(m_packet_queue.wait_dequeue_timed(packet,timeout_usecs)){
+        process_packet(packet->data);
+      }
     }
   }
-}
-
-void WBTransmitter::feedPacket2(const uint8_t *buf, size_t size,std::optional<bool> end_block) {
-  if (size <= 0 || size > FEC_MAX_PAYLOAD_SIZE) {
-    m_console->warn("Fed packet with incompatible size:",size);
-    return;
-  }
-  const auto cur_ts = std::chrono::steady_clock::now();
-  // send session key in SESSION_KEY_ANNOUNCE_DELTA intervals
-  if ((cur_ts >= session_key_announce_ts)) {
-    // Announce session key
-    sendSessionKey();
-    session_key_announce_ts = cur_ts + SESSION_KEY_ANNOUNCE_DELTA;
-  }
-  // this calls a callback internally
-  if (kEnableFec) {
-    if(end_block.has_value()){
-      // Variable FEC k (block size)
-      m_fec_encoder->encodePacket(buf, size, end_block.value());
-    }else {
-      // Fixed FEC k (block size)
-      m_fec_encoder->encodePacket(buf, size);
-    }
-    if (m_fec_encoder->resetOnOverflow()) {
-      // running out of sequence numbers should never happen during the lifetime of the TX instance, but handle it properly anyways
-      m_encryptor.makeNewSessionKey(sessionKeyPacket.sessionKeyNonce, sessionKeyPacket.sessionKeyData);
-      sendSessionKey();
-    }
-  } else {
-    m_fec_disabled_encoder->encodePacket(buf, size);
-  }
-  nInputPackets++;
 }
 
 void WBTransmitter::update_fec_percentage(uint32_t fec_percentage) {
@@ -259,13 +213,18 @@ void WBTransmitter::update_fec_k(int fec_k) {
 
 WBTxStats WBTransmitter::get_latest_stats() {
   WBTxStats ret{};
-  ret.n_injected_packets=nInjectedPackets;
-  ret.n_injected_bytes=static_cast<int64_t>(count_bytes_data_injected);
-  ret.current_injected_bits_per_second=bitrate_calculator_injected_bytes.get_last_or_recalculate(count_bytes_data_injected,std::chrono::seconds(2));
-  ret.current_provided_bits_per_second=bitrate_calculator_data_provided.get_last_or_recalculate(count_bytes_data_provided,std::chrono::seconds(2));
-  ret.count_tx_injections_error_hint=count_tx_injections_error_hint;
+  ret.n_injected_packets= m_n_injected_packets;
+  ret.n_injected_bytes=static_cast<int64_t>(m_count_bytes_data_injected);
+  ret.current_injected_bits_per_second=bitrate_calculator_injected_bytes.get_last_or_recalculate(
+          m_count_bytes_data_injected,std::chrono::seconds(2));
+  ret.current_provided_bits_per_second=
+      m_bitrate_calculator_data_provided.get_last_or_recalculate(
+          m_count_bytes_data_provided,std::chrono::seconds(2));
+  ret.count_tx_injections_error_hint= m_count_tx_injections_error_hint;
   ret.n_dropped_packets=m_n_dropped_packets;
-  ret.current_injected_packets_per_second=_packets_per_second_calculator.get_last_or_recalculate(nInjectedPackets,std::chrono::seconds(2));
+  ret.current_injected_packets_per_second=
+      m_packets_per_second_calculator.get_last_or_recalculate(
+          m_n_injected_packets,std::chrono::seconds(2));
   return ret;
 }
 
@@ -276,4 +235,37 @@ FECTxStats WBTransmitter::get_latest_fec_stats() {
     ret.curr_fec_block_length=m_fec_encoder->get_current_fec_blk_sizes();
   }
   return ret;
+}
+
+void WBTransmitter::process_packet(const std::shared_ptr<std::vector<uint8_t>>& data) {
+  announce_session_key_if_needed();
+  if (kEnableFec) {
+    m_fec_encoder->encodePacket(data->data(),data->size());
+  }else{
+    m_fec_disabled_encoder->encodePacket(data->data(),data->size());
+  }
+}
+
+void WBTransmitter::process_fec_block(const std::vector<std::shared_ptr<std::vector<uint8_t>>>& fragments,const int max_block_size) {
+  assert(kEnableFec);
+  announce_session_key_if_needed();
+  auto blocks=blocksize::split_frame_if_needed(fragments,max_block_size);
+  for(auto& block:blocks){
+    m_fec_encoder->tmp_encode_block(block);
+  }
+  if (m_fec_encoder->resetOnOverflow()) {
+    // running out of sequence numbers should never happen during the lifetime of the TX instance, but handle it properly anyways
+    m_encryptor.makeNewSessionKey(m_sess_key_packet.sessionKeyNonce,
+                                  m_sess_key_packet.sessionKeyData);
+    send_session_key();
+  }
+}
+
+void WBTransmitter::announce_session_key_if_needed() {
+  const auto cur_ts = std::chrono::steady_clock::now();
+  if (cur_ts >= m_session_key_announce_ts) {
+    // Announce session key
+    send_session_key();
+    m_session_key_announce_ts = cur_ts + SESSION_KEY_ANNOUNCE_DELTA;
+  }
 }

--- a/src/WBTransmitter.h
+++ b/src/WBTransmitter.h
@@ -194,7 +194,7 @@ class WBTransmitter {
   std::unique_ptr<std::thread> m_process_data_thread;
   bool m_process_data_thread_run=true;
   void loop_process_data();
-  // The session key is sent in regular intervalls as long as the tx instance is active (data is coming in)
+  // The session key is sent in regular intervals as long as the tx instance is active (data is coming in)
   void announce_session_key_if_needed();
   //
   void process_packet(const std::shared_ptr<std::vector<uint8_t>>& data);

--- a/src/WBTransmitter.h
+++ b/src/WBTransmitter.h
@@ -34,8 +34,6 @@
 #include "../readerwriterqueue/readerwritercircularbuffer.h"
 #include "WBTransmitterStats.hpp"
 
-// dynamic fec block size, NONE = use fixed k value
-enum class FEC_VARIABLE_INPUT_TYPE {RTP_H264, RTP_H265, RTP_MJPEG };
 
 // the following settings are only needed if fec is enabled
 struct TxFecOptions{
@@ -184,7 +182,7 @@ class WBTransmitter {
     std::optional<bool> end_block;
     std::shared_ptr<std::vector<uint8_t>> data;
   };
-  // extra data queue, to smooth out input from udp port AND more importantly, have a queue we can reason about
+  // extra data queue, to smooth out data stream spikes AND more importantly, have a queue we can reason about
   // in contrast to the linux udp socket buffer, which we cannot get any information about.
   moodycamel::BlockingReaderWriterCircularBuffer<std::shared_ptr<Item>> m_data_queue{128};
   std::unique_ptr<std::thread> m_process_data_thread;

--- a/src/WBTransmitter.h
+++ b/src/WBTransmitter.h
@@ -30,7 +30,6 @@
 #include "RawTransmitter.hpp"
 #include "wifibroadcast-spdlog.h"
 #include "wifibroadcast.hpp"
-//#include <atomic>
 #include "../readerwriterqueue/readerwritercircularbuffer.h"
 #include "WBTransmitterStats.hpp"
 

--- a/src/WBTransmitter.h
+++ b/src/WBTransmitter.h
@@ -62,6 +62,10 @@ struct TOptions {
   std::string wlan;
   // weather you are going to call the enqueue block or enqueue packet method
   bool use_block_queue=false;
+  // size of packet data queue
+  int packet_data_queue_size=64;
+  // size of block / frame data queue
+  int block_data_queue_size=2;
   // Even though setting the fec_k parameter / n of primary fragments creates similar characteristics as a link
   // without fec, we have a special impl. when fec is disabled, since there we allow packets out of order and with fec_k == 1 you'd have
   // packet re-ordering / packets out of order are not possible.


### PR DESCRIPTION
Using a queue of frames instead of (agnostic) rtp fragments improves the behaviour when the tx needs to drop data (tx errors), since the tx now drops whole frame(s) instead of parts of a frame (which results in non-decodable data). Latency is untouched by that (as long as we are not dropping frame(s) - but when frames need to be dropped, we are already in a wrongly configured state anyways). Also fixes the issue of dropped data on frame(s) consisting of more than packet queue size fragments.