### PR TITLE
feature - add 2 modes of operation, packet queue or block (frames in …

### DIFF
--- a/src/FECEnabled.hpp
+++ b/src/FECEnabled.hpp
@@ -142,7 +142,8 @@ class FECEncoder {
     for(int i=0;i<fragments.size();i++){
       const bool end_block=i==fragments.size()-1;
       const auto res=encodePacket(fragments[i]->data(),fragments[i]->size(),end_block);
-      assert(end_block==res);
+      // does not hold true if you do not use variable block length for video (do not do that ;))
+      //assert(end_block==res);
     }
   }
   /**


### PR DESCRIPTION
…OpenHD) queue. Using a queue of frames instead of (agnostic) rtp fragments improves the behaviour when the tx needs to drop data (tx errors), since the tx now drops whole frame(s) instead of parts of a frame (which results in non-decodable data). Latency is untouched by that (as long as we are not dropping frame(s) - but when frames need to be dropped, we are already in a wrongly configured state anyways). Also fixes the issue of dropped data on frame(s) consisting of more than packet queue size fragments.