### PR TITLE
Fix narrowing conversion warning

### DIFF
--- a/src/HelperSources/Helper.hpp
+++ b/src/HelperSources/Helper.hpp
@@ -209,7 +209,7 @@ static constexpr timeval durationToTimeval(nanoseconds dur) {
   const auto secs = duration_cast<seconds>(dur);
   dur -= secs;
   const auto us = duration_cast<microseconds>(dur);
-  return timeval{secs.count(), us.count()};
+  return timeval{secs.count(), (long int)us.count()};
 }
 }
 


### PR DESCRIPTION
Fix a narrowing conversion warning in a common header. Leave the 2038 problem warning.