### PR TITLE
docs: add architecture overview

### DIFF
--- a/UART_Retransmission.md
+++ b/UART_Retransmission.md
@@ -1,0 +1,54 @@
+# Retransmission über UART bei Paketverlust
+
+Dieser Leitfaden beschreibt die grundlegende Funktionsweise und enthält eine detaillierte Aufgabenliste, wie eine Retransmission für verlorene Pakete mittels UART implementiert werden kann. Die Kommunikation erfolgt dabei zwischen Empfänger und Sender über zwei UART-Schnittstellen.
+
+## Grundsätzliche Funktionsweise
+
+1. **Paketnummerierung:** Jedes gesendete Paket erhält eine fortlaufende Sequenznummer.
+2. **Überwachung beim Empfänger:** Der Empfänger protokolliert die eingehenden Sequenznummern und erkennt fehlende Pakete.
+3. **Anfrage über UART:** Erkennt der Empfänger eine Lücke in der Sequenz, sendet er eine Retransmissionsanfrage über UART an den Sender. Die Anfrage enthält mindestens die Sequenznummer des fehlenden Pakets.
+4. **Antwort des Senders:** Der Sender lauscht auf Befehle am UART, sucht das angeforderte Paket im Puffer und überträgt es erneut über den Funkkanal.
+5. **Bestätigung (optional):** Nach erfolgreichem Empfang kann der Empfänger eine Bestätigung über UART senden oder erneut um Übertragung bitten, falls das Paket noch fehlt.
+
+## Detaillierte Aufgabenliste
+
+### 1. Paketverwaltung und Sequenzierung
+- [ ] Sequenznummern für alle gesendeten Pakete vergeben.
+- [ ] Am Empfänger eine Struktur zum Nachhalten der zuletzt empfangenen Sequenznummern anlegen.
+- [ ] Erkennen von Lücken in der Sequenz (z. B. durch einen Ringpuffer oder eine Hashmap für "vermisste" Pakete).
+
+### 2. UART-Kommunikation vorbereiten
+- [ ] Geeignete Baudrate und UART-Parameter für beide Seiten festlegen.
+- [ ] UART-Schnittstelle initialisieren (Sender und Empfänger).
+- [ ] Einfaches Protokoll für Retransmissionsbefehle definieren (z. B. `0xAA <seq_high> <seq_low> 0x55`).
+
+### 3. Retransmissionsanfrage am Empfänger
+- [ ] Beim Feststellen eines fehlenden Pakets den UART-Befehl mit Sequenznummer auslösen.
+- [ ] Zeitstempel oder Wiederholungszähler anlegen, falls die Anfrage erneut gesendet werden muss.
+- [ ] Optional: Puffer für mehrere offene Anfragen führen, um mehrere Paketverluste parallel zu behandeln.
+
+### 4. Befehlsverarbeitung am Sender
+- [ ] UART im Sender kontinuierlich auf eingehende Daten prüfen.
+- [ ] Befehlspaket parsen und Sequenznummer extrahieren.
+- [ ] Gespeicherte Pakete in einem Puffer oder Ringpuffer vorhalten, damit verlorene Pakete erneut gesendet werden können.
+- [ ] Angefordertes Paket erneut über den Hauptübertragungskanal (z. B. WiFi) senden.
+
+### 5. Optionale Bestätigungen
+- [ ] Empfänger bestätigt per UART, dass das nachgesendete Paket erfolgreich empfangen wurde.
+- [ ] Sender verwirft das Paket aus dem Puffer nach erfolgreicher Bestätigung oder nach einem Timeout.
+
+### 6. Fehlerbehandlung und Timeouts
+- [ ] Wenn der Sender das angeforderte Paket nicht mehr besitzt, Fehlermeldung oder Negativbestätigung über UART senden.
+- [ ] Wiederholte Retransmissionsanfragen begrenzen, um Endlosschleifen zu vermeiden.
+- [ ] Logging und Debug-Ausgaben implementieren, um Paketverlust und Retransmissionen nachvollziehen zu können.
+
+### 7. Tests und Validierung
+- [ ] UART-Verbindung im Labor testen (Loopback oder zwei Geräte).
+- [ ] Paketverluste gezielt erzeugen (z. B. durch Dropping im Code) und sicherstellen, dass Retransmission ausgelöst wird.
+- [ ] Performance messen: zusätzliche Latenz durch Retransmission und UART-Overhead beobachten.
+- [ ] Stress-Test mit vielen gleichzeitigen Anfragen durchführen.
+
+## Ausblick
+
+Die beschriebenen Schritte bilden einen Ausgangspunkt. Erweiterungen könnten eine Priorisierung von kritischen Paketen, Verschlüsselung der UART-Kommandos oder eine adaptivere Strategie für wiederholte Paketverluste umfassen.
+

--- a/WiFiBroadcast_Architecture.md
+++ b/WiFiBroadcast_Architecture.md
@@ -1,0 +1,39 @@
+# WiFiBroadcast – Architektur und Zusammenspiel der Komponenten
+
+## Überblick
+WiFiBroadcast ist eine C++‑Bibliothek für Video‑ und Telemetrie‑Streaming über WLAN. Sie bietet Multiplexing, optionale Verschlüsselung sowie ausführliche Debug‑Statistiken.
+
+## Kernkomponente: `WBTxRx`
+`WBTxRx` stellt die niedrigstufige Schnittstelle zum WLAN‑Adapter bereit. Die Klasse kapselt Senden und Empfangen, verwaltet Schlüssel und erlaubt mehrere gleichzeitige Streams über einen sogenannten *radio_port*. Wichtige Eigenschaften:
+
+- Selektive Verschlüsselung und Validierung pro Paket (Overhead ~16 Byte)
+- Registrierung von Callbacks für eingehende Pakete oder spezifische Streams
+- Statistiken zu Paket‑ und Bitraten für TX und RX
+
+## Streams auf höherer Ebene
+### `WBStreamTx`
+Der Sender für einen einzelnen Stream baut auf `WBTxRx` auf und kann FEC einsetzen oder deaktivieren. Über optionale Warteschlangen werden Pakete oder Frames verarbeitet und bei Bedarf mehrfach injiziert, um Paketverluste zu reduzieren. Statistiken liefern Informationen über Durchsatz und verworfene Pakete.
+
+### `WBStreamRx`
+Der Empfänger ergänzt `WBTxRx` um die Rekonstruktion von Daten. Er dekodiert FEC‑geschützte Blöcke oder arbeitet im einfachen Sequenzmodus und kann optional in einem separaten Thread laufen. Umfangreiche Zähler erfassen Eingangs‑ und Ausgangsbitrate sowie FEC‑Ergebnisse.
+
+### `WBVideoStreamTx`
+Für Videodaten existiert der spezialisierte `WBVideoStreamTx`, der komplette Frames entgegennimmt, sie in Fragmente zerlegt und per FEC absichert. Ein eigener Thread zieht Frames aus einer Queue und injiziert sie über `WBTxRx`.
+
+## Unterstützende Module
+- **FECDisabled (`SimpleStream.hpp`)** – fügt Sequenznummern hinzu und verwirft Duplikate, erlaubt aber Pakete außerhalb der Reihenfolge, was für Telemetrie geeignet ist
+- **FunkyQueue** – threadsichere Queue für das Producer/Consumer‑Muster; bietet spezielle Operationen zum Leeren bei Überlastung oder zeitgesteuertes Dequeueing
+- **WiFiCard** – schlanke Abstraktion der verwendeten WLAN‑Karten inklusive Emulationsmodi für Tests
+- **Externe Bibliotheken** – FEC‑ und Radiotap‑Implementierungen stammen aus externen Projekten und werden unter `lib/` mitgeführt
+
+## Beispielprogramme
+Das Repository enthält mehrere ausführbare Beispiele. `example_hello` zeigt den grundlegenden Austausch von Textnachrichten zwischen Luft‑ und Bodenstation. `example_udp` leitet UDP‑Pakete über einen Wifibroadcast‑Stream weiter und unterstützt optional FEC. Weitere Beispiele wie `benchmark` demonstrieren Performance‑Messungen.
+
+## Datenfluss
+1. Anwendung erzeugt Nutzdaten (z. B. Frame oder Telemetriebefehl).
+2. Ein Sender (`WBStreamTx` oder `WBVideoStreamTx`) fragmentiert die Daten, wendet optional FEC und Verschlüsselung an und übergibt sie an `WBTxRx`.
+3. `WBTxRx` fügt Radiotap- und IEEE80211‑Header an, injiziert das Paket über den WLAN‑Adapter und führt Statistiken.
+4. Auf der Empfängerseite verteilt `WBTxRx` Pakete anhand des `radio_port` an die jeweiligen `WBStreamRx`‑Instanzen, die Daten rekonstruieren und an die Anwendung weitergeben.
+
+## Fazit
+Durch die klare Trennung zwischen der basalen Link‑Verwaltung (`WBTxRx`) und den darauf aufsetzenden Streams erlaubt WiFiBroadcast flexible Kombinationen von Video‑ und Telemetriebefehlen bei geringer Latenz und optionaler Fehlerkorrektur.


### PR DESCRIPTION
## Summary
- Document WiFiBroadcast architecture and component relationships

## Testing
- `./run_clang_format.sh` (fails: code should be clang-formatted)
- `cmake -S . -B build` (fails: Could not find a package configuration file provided by "spdlog")

------
https://chatgpt.com/codex/tasks/task_e_68ae495075bc832f9e3d2320d497662f